### PR TITLE
Fixed ToonBasicOutline shader missing XR macros

### DIFF
--- a/Assets/_CompletedDemos/ToonOutlinePostprocessCompleted/Shaders/ToonBasicOutline.shader
+++ b/Assets/_CompletedDemos/ToonOutlinePostprocessCompleted/Shaders/ToonBasicOutline.shader
@@ -34,7 +34,7 @@ Shader "Toon/Basic Outline"
             {
                 float4 positionOS : POSITION;
                 float3 normalOS : NORMAL;
-				UNITY_VERTEX_INPUT_INSTANCE_ID
+                UNITY_VERTEX_INPUT_INSTANCE_ID
             };
         
             struct Varyings 
@@ -42,7 +42,7 @@ Shader "Toon/Basic Outline"
                 float4 positionCS : SV_POSITION;
                 half fogCoord : TEXCOORD0;
                 half4 color : COLOR;
-				UNITY_VERTEX_OUTPUT_STEREO
+                UNITY_VERTEX_OUTPUT_STEREO
             };
             
             Varyings vert(Attributes input) 

--- a/Assets/_CompletedDemos/ToonOutlinePostprocessCompleted/Shaders/ToonBasicOutline.shader
+++ b/Assets/_CompletedDemos/ToonOutlinePostprocessCompleted/Shaders/ToonBasicOutline.shader
@@ -34,6 +34,7 @@ Shader "Toon/Basic Outline"
             {
                 float4 positionOS : POSITION;
                 float3 normalOS : NORMAL;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
             };
         
             struct Varyings 
@@ -41,12 +42,15 @@ Shader "Toon/Basic Outline"
                 float4 positionCS : SV_POSITION;
                 half fogCoord : TEXCOORD0;
                 half4 color : COLOR;
+				UNITY_VERTEX_OUTPUT_STEREO
             };
             
             Varyings vert(Attributes input) 
             {
                 Varyings output = (Varyings)0;
-                
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+	
                 input.positionOS.xyz += input.normalOS.xyz * _Outline;
                 
                 VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);


### PR DESCRIPTION
- Added XR macros to ToonBasicOutline shader.

To QA:
This PR fixed Assets\_CompletedDemos\ToonOutlinePostprocessCompleted demo not working in XR.
Please verify this demo works for 19.3+7.x.x(shim XRSDK) and latest trunk+URP master(Pure XRSDK)