### PR TITLE
Fix/compatibility deferred

### DIFF
--- a/Assets/_CompletedDemos/3DSkybox/Nodes/CustomNodes.hlsl
+++ b/Assets/_CompletedDemos/3DSkybox/Nodes/CustomNodes.hlsl
@@ -15,7 +15,7 @@ void FindColor_float(float4 waterDeep, float4 waterShallow, float4 landLow, floa
     float4 waterColor = lerp(waterDeep, waterShallow, saturate(value/waterHeight));
     float4 landColor = lerp(landLow, landHigh, saturate((value-waterHeight)/(1-waterHeight)));
     float isWater = step(value, waterHeight);
-    color = waterColor * isWater+ landColor * (1-isWater);
+    color = saturate(waterColor * isWater + landColor * (1-isWater));
 }
 
 #endif

--- a/Assets/_CompletedDemos/3DSkybox/Rendering/3dSkyBox_Planets.asset
+++ b/Assets/_CompletedDemos/3DSkybox/Rendering/3dSkyBox_Planets.asset
@@ -13,13 +13,18 @@ MonoBehaviour:
   m_Name: 3dSkyBox_Planets
   m_EditorClassIdentifier: 
   m_RendererFeatures: []
+  m_RendererFeatureMap: 
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
   shaders:
     blitPS: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
     copyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
     screenSpaceShadowPS: {fileID: 4800000, guid: 0f854b35a0cf61a429bd5dcfea30eddd,
       type: 3}
     samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
+    tileDepthInfoPS: {fileID: 4800000, guid: f451c6bec16aa51408bdfd37f70aed12, type: 3}
+    tileDeferredPS: {fileID: 4800000, guid: 344787727e03649488a1022c09fa74b5, type: 3}
+    stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
     fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
   m_OpaqueLayerMask:
     serializedVersion: 2
@@ -29,9 +34,11 @@ MonoBehaviour:
     m_Bits: 4294967295
   m_DefaultStencilState:
     overrideStencilState: 1
-    stencilReference: 0
-    stencilCompareFunction: 3
-    passOperation: 5
-    failOperation: 5
+    stencilReference: 1
+    stencilCompareFunction: 6
+    passOperation: 2
+    failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
+  m_RenderingMode: 1
+  m_AccurateGbufferNormals: 0

--- a/Assets/_CompletedDemos/3DSkybox/Rendering/3dSkyBox_Ship.asset
+++ b/Assets/_CompletedDemos/3DSkybox/Rendering/3dSkyBox_Ship.asset
@@ -13,13 +13,18 @@ MonoBehaviour:
   m_Name: 3dSkyBox_Ship
   m_EditorClassIdentifier: 
   m_RendererFeatures: []
+  m_RendererFeatureMap: 
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
   shaders:
     blitPS: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
     copyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
     screenSpaceShadowPS: {fileID: 4800000, guid: 0f854b35a0cf61a429bd5dcfea30eddd,
       type: 3}
     samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
+    tileDepthInfoPS: {fileID: 4800000, guid: f451c6bec16aa51408bdfd37f70aed12, type: 3}
+    tileDeferredPS: {fileID: 4800000, guid: 344787727e03649488a1022c09fa74b5, type: 3}
+    stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
     fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
   m_OpaqueLayerMask:
     serializedVersion: 2
@@ -35,3 +40,5 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
+  m_RenderingMode: 1
+  m_AccurateGbufferNormals: 0

--- a/Assets/_CompletedDemos/3DSkybox/Rendering/3dSkyBox_StarBox.asset
+++ b/Assets/_CompletedDemos/3DSkybox/Rendering/3dSkyBox_StarBox.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c7228b9000a2c469ba86bd89eed697fd, type: 3}
   m_Name: NewSkyboxRenderFeature
   m_EditorClassIdentifier: 
+  m_Active: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26,13 +27,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_RendererFeatures:
   - {fileID: -6629991880920328942}
+  m_RendererFeatureMap: 
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
   shaders:
     blitPS: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
     copyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
     screenSpaceShadowPS: {fileID: 4800000, guid: 0f854b35a0cf61a429bd5dcfea30eddd,
       type: 3}
     samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
+    tileDepthInfoPS: {fileID: 4800000, guid: f451c6bec16aa51408bdfd37f70aed12, type: 3}
+    tileDeferredPS: {fileID: 4800000, guid: 344787727e03649488a1022c09fa74b5, type: 3}
+    stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
     fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
   m_OpaqueLayerMask:
     serializedVersion: 2
@@ -42,9 +48,11 @@ MonoBehaviour:
     m_Bits: 4294967295
   m_DefaultStencilState:
     overrideStencilState: 1
-    stencilReference: 0
-    stencilCompareFunction: 3
-    passOperation: 0
+    stencilReference: 1
+    stencilCompareFunction: 6
+    passOperation: 2
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
+  m_RenderingMode: 1
+  m_AccurateGbufferNormals: 0


### PR DESCRIPTION
Small fixes to make test scenes to be compatible with deferred renderer, following QA testing:
- 3D skybox test scenes use stencil overrides which are compatible with deferred
- a shader graph material is not outputing albedo values beyond 1.0.
